### PR TITLE
feat: 이메일 인증 API 생성

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,10 @@
             <artifactId>gson</artifactId>
             <version>2.8.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/pangtudy/userapi/user/controller/AuthController.java
+++ b/src/main/java/com/pangtudy/userapi/user/controller/AuthController.java
@@ -33,4 +33,26 @@ public class AuthController {
         return user.getUsername();
     }
 
+    @PostMapping("/verify")
+    public Object verify(@RequestBody UserParam param) {
+        String response = "성공적으로 인증메일을 보냈습니다.";
+        try {
+            authService.sendVerificationMail(param);
+        } catch (Exception exception) {
+            response = "인증메일을 보내는데 문제가 발생했습니다.";
+        }
+        return response;
+    }
+
+    @GetMapping("/verify/{key}")
+    public Object getVerify(@PathVariable String key) {
+        String response = "성공적으로 인증메일을 확인했습니다.";
+        try {
+            authService.verifyEmail(key);
+        } catch (Exception e) {
+            response = "인증메일을 확인하는데 실패했습니다.";
+        }
+        return response;
+    }
+
 }

--- a/src/main/java/com/pangtudy/userapi/user/model/UserEntity.java
+++ b/src/main/java/com/pangtudy/userapi/user/model/UserEntity.java
@@ -24,6 +24,7 @@ public class UserEntity {
     @Setter
     private String password;
 
+    @Setter
     @Column(name = "role")
     @Enumerated(EnumType.STRING)
     private UserRole role = UserRole.ROLE_NOT_PERMITTED;

--- a/src/main/java/com/pangtudy/userapi/user/service/AuthService.java
+++ b/src/main/java/com/pangtudy/userapi/user/service/AuthService.java
@@ -1,6 +1,9 @@
 package com.pangtudy.userapi.user.service;
 
+import com.pangtudy.userapi.user.config.UserRole;
+import com.pangtudy.userapi.user.model.UserEntity;
 import com.pangtudy.userapi.user.model.UserParam;
+import javassist.NotFoundException;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -8,4 +11,10 @@ public interface AuthService {
     Object signUpUser(UserParam param);
 
     Object loginUser(UserParam param, HttpServletResponse res);
+
+    void sendVerificationMail(UserParam param) throws NotFoundException;
+
+    void verifyEmail(String key) throws NotFoundException;
+
+    void modifyUserRole(UserEntity user, UserRole userRole);
 }

--- a/src/main/java/com/pangtudy/userapi/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/pangtudy/userapi/user/service/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package com.pangtudy.userapi.user.service;
 
+import com.pangtudy.userapi.user.config.UserRole;
 import com.pangtudy.userapi.user.model.UserEntity;
 import com.pangtudy.userapi.user.model.UserParam;
 import com.pangtudy.userapi.user.model.UserResult;
@@ -8,6 +9,7 @@ import com.pangtudy.userapi.user.util.CookieUtil;
 import com.pangtudy.userapi.user.util.JwtUtil;
 import com.pangtudy.userapi.user.util.RedisUtil;
 import com.pangtudy.userapi.user.util.SaltUtil;
+import javassist.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.transaction.Transactional;
 import java.util.Optional;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
@@ -23,6 +26,7 @@ public class AuthServiceImpl implements AuthService {
 
     private final ModelMapper modelMapper;
     private final UserRepository userRepository;
+    private final EmailService emailService;
     private final SaltUtil saltUtil;
     private final JwtUtil jwtUtil;
     private final CookieUtil cookieUtil;
@@ -61,6 +65,31 @@ public class AuthServiceImpl implements AuthService {
         }
 
         return null;
+    }
+
+    @Override
+    public void sendVerificationMail(UserParam param) throws NotFoundException {
+        if (userRepository.findByEmail(param.getEmail()) == null) throw new NotFoundException("멤버가 조회되지 않음");
+
+        String VERIFICATION_LINK = "http://localhost:8080/auth/verify/";
+        UUID uuid = UUID.randomUUID();
+        redisUtil.setDataExpire(uuid.toString(), param.getEmail(), 60 * 30L);
+        emailService.sendMail(param.getEmail(), "[Pangtudy] 회원가입 인증메일입니다.", VERIFICATION_LINK + uuid.toString());
+    }
+
+    @Override
+    public void verifyEmail(String key) throws NotFoundException {
+        String email = redisUtil.getData(key);
+        Optional<UserEntity> user = userRepository.findByEmail(email);
+        if (Optional.ofNullable(user).isEmpty()) throw new NotFoundException("멤버가 조회되지않음");
+        modifyUserRole(user.get(), UserRole.ROLE_USER);
+        redisUtil.deleteData(key);
+    }
+
+    @Override
+    public void modifyUserRole(UserEntity user, UserRole userRole){
+        user.setRole(userRole);
+        userRepository.save(user);
     }
 
     private <R, T> T sourceToDestinationTypeCasting(R source, T destination) {

--- a/src/main/java/com/pangtudy/userapi/user/service/EmailService.java
+++ b/src/main/java/com/pangtudy/userapi/user/service/EmailService.java
@@ -1,0 +1,5 @@
+package com.pangtudy.userapi.user.service;
+
+public interface EmailService {
+    void sendMail(String to, String sub, String text);
+}

--- a/src/main/java/com/pangtudy/userapi/user/service/EmailServiceImpl.java
+++ b/src/main/java/com/pangtudy/userapi/user/service/EmailServiceImpl.java
@@ -1,0 +1,23 @@
+package com.pangtudy.userapi.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class EmailServiceImpl implements EmailService {
+
+    private final JavaMailSender emailSender;
+
+    @Override
+    public void sendMail(String to,String sub, String text){
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject(sub);
+        message.setText(text);
+        emailSender.send(message);
+    }
+
+}

--- a/src/main/java/com/pangtudy/userapi/user/util/RedisUtil.java
+++ b/src/main/java/com/pangtudy/userapi/user/util/RedisUtil.java
@@ -29,4 +29,8 @@ public class RedisUtil {
         valueOperations.set(key, value, expireDuration);
     }
 
+    public void deleteData(String key){
+        stringRedisTemplate.delete(key);
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,11 @@ spring.jwt.secret = pangtudypangtudypangtudypangtudypangtudypangtudypangtudypang
 spring.cache.type = redis
 spring.redis.host = localhost
 spring.redis.port = 6379
+
+# Email Send Configuration_SMTP
+spring.mail.host = smtp.gmail.com
+spring.mail.port = 587
+spring.mail.username = USERID
+spring.mail.password = USERPASSWORD
+spring.mail.properties.mail.smtp.auth = true
+spring.mail.properties.mail.smtp.starttls.enable = true


### PR DESCRIPTION
이메일 인증용 메일을 전송하는 API 생성(/auth/verify)
전송된 메일을 클릭했을 때 인증을 수행하는 API 생성(/auth/verify/:key)